### PR TITLE
Count total countries before slicing

### DIFF
--- a/app/routes/public/rankings.py
+++ b/app/routes/public/rankings.py
@@ -180,10 +180,11 @@ def render_country_page(
 ) -> str:
     # Get country ranking
     leaderboard = [country for country in leaderboards.top_countries(mode) if country['name'] != 'xx']
-    leaderboard = leaderboard[(page - 1)*items_per_page:(page - 1)*items_per_page + items_per_page]
 
     country_count = len(leaderboard)
     total_pages = max(1, min(10000, math.ceil(country_count / items_per_page)))
+    
+    leaderboard = leaderboard[(page - 1)*items_per_page:(page - 1)*items_per_page + items_per_page]
 
     # Get min/max pages to display for pagination
     max_page_display = max(page, min(total_pages, page + 8))


### PR DESCRIPTION
`country_count` will always be `items_per_page` after slicing `leaderboard` thus making `total_pages` always 1

https://osu.titanic.sh/rankings/osu/country?page=2