### PR TITLE
Add "Total Kudosu Earned" line to General profile tab

### DIFF
--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -369,7 +369,7 @@
                                 <b>Total Hits</b>: {{ "{:,}".format(current_stats.total_hits) }}
                             </h4>
                             <br>
-                            <h4 class="profile-stats-element" title="Total notes hit.">
+                            <h4 class="profile-stats-element" title="Highest combo achieved (hits in a row without a miss).">
                                 <b>Maximum Combo</b>: {{ "{:,}".format(current_stats.max_combo) }}
                             </h4>
                             <br>


### PR DESCRIPTION
item 1 of https://osu.titanic.sh/forum/6/t/2032/ (but there's no link on "Kudosu")

it's already in the kudosu tab, but it's supposed to be here too