### PR TITLE
Match main BG positioning and colors to old osu! website

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -96,7 +96,7 @@ html {
 }
 
 html[data-darkreader-mode="dynamic"] {
-    background: linear-gradient(#475280, #2f3b6a 180px) !important;
+    background: linear-gradient(#313a5a, #070606 180px) !important;
 }
 
 input:focus {


### PR DESCRIPTION
I was trying to get the colors exact using `linear-gradient`, but it turns out that gradient is not actually linear. it also turns out the original image in base64 is less bytes than the CSS so might as well go all the way...

I adjusted the dark reader version too to roughly match the position/size